### PR TITLE
oprava superselectu

### DIFF
--- a/widgets/superselect/superselect.js
+++ b/widgets/superselect/superselect.js
@@ -722,8 +722,8 @@ JAK.SuperSelect.prototype._open = function(e,elm){
 		
 		this.dom.optionsRoot.style.left = optionsPos+'px';-*/
 	}
-	var event = this.opt.noFocusElm ? 'mousedown' : 'click'
-	if(!this.wc){ this.wc = JAK.Events.addListener(window, event, this, '_windowClick'); }
+	var event = this.opt.noFocusElm ? 'mousedown' : 'click';
+	if(!this.wc){ this.wc = JAK.Events.addListener(document, event, this, '_windowClick'); }
 };
 
 JAK.SuperSelect.prototype._setBoxesTop = function(){


### PR DESCRIPTION
při kliknutí mimo superselect se v IE7 a 8  superselect nezavířel
