### PR TITLE
Uploader 2.1

### DIFF
--- a/widgets/uploader/uploader.js
+++ b/widgets/uploader/uploader.js
@@ -1,6 +1,6 @@
 /**
  * @overview Komponenta nabízející asynchronní upload souborů 
- * @version 2.0
+ * @version 2.1
  * @author ethan
  */
  


### PR DESCRIPTION
Opraven bug, kdy od určité velikosti písma IE8 kazil inline styly a tím rozbil formátování. Jako perličku mohu říct, že maximální velikost písma inputu (na pokusné stránce) byla 2407px, větší už způsobovala rozbití CSS. Naprosto netuším, co to tam vyvádí, takže bezpečnou a pro drtivou většinu případů jistě dostačující velikostí byla zvolena velikost 1200px.
