### PR TITLE
JAK.HTML5Form - oprava selhavajiciho testu v IE 10 a IE11

### DIFF
--- a/util/html5form/html5form-all.js
+++ b/util/html5form/html5form-all.js
@@ -338,6 +338,19 @@ JAK.HTML5Form.SupportTester.prototype._testInput = function (dname) {
 	var i = JAK.mel('input');
 	var type = dname.replace('input', '');
 	i.setAttribute('type', type);
+
+	if (type == "number") {
+		// IE10-11 má jen částečnou podporu number inputu
+		try {
+			i.value = 1;
+			i.stepUp();
+			this._results[dname] = true;
+		} catch (err) {
+			this._results[dname] = false;
+		}
+		return;
+	}
+
 	this._results[dname] = i.type == type;
 };
 

--- a/util/html5form/html5form-tester.js
+++ b/util/html5form/html5form-tester.js
@@ -62,6 +62,19 @@ JAK.HTML5Form.SupportTester.prototype._testInput = function (dname) {
 	var i = JAK.mel('input');
 	var type = dname.replace('input', '');
 	i.setAttribute('type', type);
+
+	if (type == "number") {
+		// IE10-11 má jen částečnou podporu number inputu
+		try {
+			i.value = 1;
+			i.stepUp();
+			this._results[dname] = true;
+		} catch (err) {
+			this._results[dname] = false;
+		}
+		return;
+	}
+
 	this._results[dname] = i.type == type;
 };
 


### PR DESCRIPTION
IE10 a IE11 se tváří, že number inputu umí, ale podporují ho jen částečně. Objekt input elementu sice obsahuje metody "stepUp" a "stepDown", ty ale při zavolání hází chybu. U inputu se ani nezobrazují ovladací tlačítka pro zvýšení/snížení hodnoty. Vypadá to, že jediné, co umí, je input správně zvalidovat. Přidal jsem proto test, jestli dané funkce správně fungují správně.

Pozn.: Testy pořád selhávají v novejších IE přepnutých do režímu IE9 a 8, protože v se v nich nedá poznat input typu "range" (elm.getAttribute("type") vrací "text"). V nativních verzích prohlížečů testy projdou.
