### PR TITLE
JAK.Tooltip - noHideOverTooltip option

### DIFF
--- a/widgets/tooltip/tooltip.js
+++ b/widgets/tooltip/tooltip.js
@@ -201,7 +201,7 @@ JAK.Tooltip.prototype._hide = function (e, elm) {
 
 	if (this.options.noHideOverTooltip) {
 		// nechceme schovávat pokud bylo najeto myší přímo nad tooltip
-		if (JAK.DOM.findParent(e.explicitOriginalTarget, ".jak-tooltip")) {
+		if (JAK.DOM.findParent(e.relatedTarget, ".jak-tooltip")) {
 			return;
 		}
 	}


### PR DESCRIPTION
Přidána možnost zrušit schovávání tooltipu, pokud ze spouštěcího elementu najedu rovnou nad bublinu tooltipu. Hodí se to v např. tehdy, chceme-li kliknout na odkaz uvnitř tooltipu. Doteď nebyla šance, jak na takový odkaz kliknout, protože se tooltip (ve výchozím nastavení )schoval okamžitě při mouseout události na spouštěcím elementu.

Defaultně je volba vypnutá, aby se widget choval stějně jako dosud.

Ukázka: http://jsfiddle.net/jirikuchta/M8mWm/2/
