### PR TITLE
Not so strict behavior in removeListener

### DIFF
--- a/lib/signals.js
+++ b/lib/signals.js
@@ -92,7 +92,7 @@ JAK.Signals.prototype.addListener = function(owner, type, funcOrString, sender){
  */
 JAK.Signals.prototype.removeListener = function(id) {
 	var typeFolders = this._myIdFolder[id];
-	if (!typeFolders) { throw new Error("Cannot remove non-existent signal ID '"+id+"'"); }
+	if (!typeFolders) { console.error("Cannot remove non-existent signal ID '"+id+"'"); }
 	
 	while (typeFolders.length) {
 		var typeFolder = typeFolders.pop();


### PR DESCRIPTION
After some debate it has been decided to fail almost silently when removing a non-existent listener. The developer still gets the message (in form of a console.error() call) that warns him about a possible flaw in his code but the application does not break.
