### PR TITLE
change className to getAttribute/setAttribute in classList to support SVG elements

### DIFF
--- a/lib/jak.js
+++ b/lib/jak.js
@@ -612,8 +612,8 @@ if (!("classList" in document.documentElement) && window.Element) {
 
 		function DOMTokenList(elm) {
 			this._element = elm;
-			if (elm.getAttribute("class") == this._classCache) { return; }
-			this._classCache = elm.getAttribute("class");
+			if (elm.className == this._classCache) { return; }
+			this._classCache = elm.className;
 			if (!this._classCache) { return; }
 
 			var classes = this._classCache.replace(/^\s+|\s+$/g,'').split(/\s+/);
@@ -624,7 +624,7 @@ if (!("classList" in document.documentElement) && window.Element) {
 		window.DOMTokenList = DOMTokenList;
 
 		function setToClassName(el, classes) {
-			el.setAttribute("class", classes.join(" "));
+			el.className = classes.join(" ");
 		}
 
 		DOMTokenList.prototype = {

--- a/lib/jak.js
+++ b/lib/jak.js
@@ -612,8 +612,8 @@ if (!("classList" in document.documentElement) && window.Element) {
 
 		function DOMTokenList(elm) {
 			this._element = elm;
-			if (elm.className == this._classCache) { return; }
-			this._classCache = elm.className;
+			if (elm.getAttribute("class") == this._classCache) { return; }
+			this._classCache = elm.getAttribute("class");
 			if (!this._classCache) { return; }
 
 			var classes = this._classCache.replace(/^\s+|\s+$/g,'').split(/\s+/);
@@ -624,7 +624,7 @@ if (!("classList" in document.documentElement) && window.Element) {
 		window.DOMTokenList = DOMTokenList;
 
 		function setToClassName(el, classes) {
-			el.className = classes.join(" ");
+			el.setAttribute("class", classes.join(" "));
 		}
 
 		DOMTokenList.prototype = {

--- a/lib/polyfills/classList.js
+++ b/lib/polyfills/classList.js
@@ -9,8 +9,8 @@ if (!("classList" in document.documentElement) && window.Element) {
 
 		function DOMTokenList(elm) {
 			this._element = elm;
-			if (elm.className == this._classCache) { return; }
-			this._classCache = elm.className;
+			if (elm.getAttribute("class") == this._classCache) { return; }
+			this._classCache = elm.getAttribute("class");
 			if (!this._classCache) { return; }
 
 			var classes = this._classCache.replace(/^\s+|\s+$/g,'').split(/\s+/);
@@ -21,7 +21,7 @@ if (!("classList" in document.documentElement) && window.Element) {
 		window.DOMTokenList = DOMTokenList;
 
 		function setToClassName(el, classes) {
-			el.className = classes.join(" ");
+			el.setAttribute("class", classes.join(" "));
 		}
 
 		DOMTokenList.prototype = {


### PR DESCRIPTION
className on SVG elements returns SVGAnimatedString object, but we expect a string value. To get a string every time, we can use getAttribute instead.